### PR TITLE
Fix postinstall scripts for a win32 environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mdn-confluence",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9,27 +9,27 @@
       "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-1.7.0.tgz",
       "integrity": "sha512-QaAxzCkbhspwajoaEnT0GcnQcpjPRcBrHYuQsXtD05BtOJgVnHCLXSsfUiRdU0nVpK+Thp7+sTkQ0fvk5PanKg==",
       "requires": {
-        "@google-cloud/common": "0.17.0",
-        "arrify": "1.0.1",
-        "async": "2.6.0",
-        "compressible": "2.0.14",
-        "concat-stream": "1.6.0",
-        "create-error-class": "3.0.2",
-        "duplexify": "3.5.3",
-        "extend": "3.0.1",
-        "gcs-resumable-upload": "0.10.2",
-        "hash-stream-validation": "0.2.1",
-        "is": "3.2.1",
-        "mime": "2.3.1",
-        "mime-types": "2.1.17",
-        "once": "1.4.0",
-        "pumpify": "1.5.1",
-        "request": "2.87.0",
-        "safe-buffer": "5.1.1",
-        "snakeize": "0.1.0",
-        "stream-events": "1.0.2",
-        "through2": "2.0.3",
-        "xdg-basedir": "3.0.0"
+        "@google-cloud/common": "^0.17.0",
+        "arrify": "^1.0.0",
+        "async": "^2.0.1",
+        "compressible": "^2.0.12",
+        "concat-stream": "^1.5.0",
+        "create-error-class": "^3.0.2",
+        "duplexify": "^3.5.0",
+        "extend": "^3.0.0",
+        "gcs-resumable-upload": "^0.10.2",
+        "hash-stream-validation": "^0.2.1",
+        "is": "^3.0.1",
+        "mime": "^2.2.0",
+        "mime-types": "^2.0.8",
+        "once": "^1.3.1",
+        "pumpify": "^1.5.1",
+        "request": "^2.85.0",
+        "safe-buffer": "^5.1.1",
+        "snakeize": "^0.1.0",
+        "stream-events": "^1.0.1",
+        "through2": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       },
       "dependencies": {
         "@google-cloud/common": {
@@ -37,24 +37,24 @@
           "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-0.17.0.tgz",
           "integrity": "sha512-HRZLSU762E6HaKoGfJGa8W95yRjb9rY7LePhjaHK9ILAnFacMuUGVamDbTHu1csZomm1g3tZTtXfX/aAhtie/Q==",
           "requires": {
-            "array-uniq": "1.0.3",
-            "arrify": "1.0.1",
-            "concat-stream": "1.6.0",
-            "create-error-class": "3.0.2",
-            "duplexify": "3.5.3",
-            "ent": "2.2.0",
-            "extend": "3.0.1",
-            "google-auto-auth": "0.10.1",
-            "is": "3.2.1",
+            "array-uniq": "^1.0.3",
+            "arrify": "^1.0.1",
+            "concat-stream": "^1.6.0",
+            "create-error-class": "^3.0.2",
+            "duplexify": "^3.5.0",
+            "ent": "^2.2.0",
+            "extend": "^3.0.1",
+            "google-auto-auth": "^0.10.0",
+            "is": "^3.2.0",
             "log-driver": "1.2.7",
-            "methmeth": "1.1.0",
-            "modelo": "4.2.3",
-            "request": "2.87.0",
-            "retry-request": "3.3.1",
-            "split-array-stream": "1.0.3",
-            "stream-events": "1.0.2",
-            "string-format-obj": "1.1.1",
-            "through2": "2.0.3"
+            "methmeth": "^1.1.0",
+            "modelo": "^4.2.0",
+            "request": "^2.79.0",
+            "retry-request": "^3.0.0",
+            "split-array-stream": "^1.0.0",
+            "stream-events": "^1.0.1",
+            "string-format-obj": "^1.1.0",
+            "through2": "^2.0.3"
           }
         },
         "gcp-metadata": {
@@ -62,8 +62,8 @@
           "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
           "integrity": "sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==",
           "requires": {
-            "axios": "0.18.0",
-            "extend": "3.0.1",
+            "axios": "^0.18.0",
+            "extend": "^3.0.1",
             "retry-axios": "0.3.2"
           }
         },
@@ -72,13 +72,13 @@
           "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.6.1.tgz",
           "integrity": "sha512-jYiWC8NA9n9OtQM7ANn0Tk464do9yhKEtaJ72pKcaBiEwn4LwcGYIYOfwtfsSm3aur/ed3tlSxbmg24IAT6gAg==",
           "requires": {
-            "axios": "0.18.0",
-            "gcp-metadata": "0.6.3",
-            "gtoken": "2.3.0",
-            "jws": "3.1.5",
-            "lodash.isstring": "4.0.1",
-            "lru-cache": "4.1.3",
-            "retry-axios": "0.3.2"
+            "axios": "^0.18.0",
+            "gcp-metadata": "^0.6.3",
+            "gtoken": "^2.3.0",
+            "jws": "^3.1.5",
+            "lodash.isstring": "^4.0.1",
+            "lru-cache": "^4.1.3",
+            "retry-axios": "^0.3.2"
           }
         },
         "google-auto-auth": {
@@ -86,10 +86,10 @@
           "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.10.1.tgz",
           "integrity": "sha512-iIqSbY7Ypd32mnHGbYctp80vZzXoDlvI9gEfvtl3kmyy5HzOcrZCIGCBdSlIzRsg7nHpQiHE3Zl6Ycur6TSodQ==",
           "requires": {
-            "async": "2.6.0",
-            "gcp-metadata": "0.6.3",
-            "google-auth-library": "1.6.1",
-            "request": "2.87.0"
+            "async": "^2.3.0",
+            "gcp-metadata": "^0.6.1",
+            "google-auth-library": "^1.3.1",
+            "request": "^2.79.0"
           }
         },
         "google-p12-pem": {
@@ -97,8 +97,8 @@
           "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.2.tgz",
           "integrity": "sha512-+EuKr4CLlGsnXx4XIJIVkcKYrsa2xkAmCvxRhX2HsazJzUBAJ35wARGeApHUn4nNfPD03Vl057FskNr20VaCyg==",
           "requires": {
-            "node-forge": "0.7.5",
-            "pify": "3.0.0"
+            "node-forge": "^0.7.4",
+            "pify": "^3.0.0"
           }
         },
         "gtoken": {
@@ -106,11 +106,11 @@
           "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
           "integrity": "sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==",
           "requires": {
-            "axios": "0.18.0",
-            "google-p12-pem": "1.0.2",
-            "jws": "3.1.5",
-            "mime": "2.3.1",
-            "pify": "3.0.0"
+            "axios": "^0.18.0",
+            "google-p12-pem": "^1.0.0",
+            "jws": "^3.1.4",
+            "mime": "^2.2.0",
+            "pify": "^3.0.0"
           }
         },
         "jws": {
@@ -118,8 +118,8 @@
           "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
           "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
           "requires": {
-            "jwa": "1.1.5",
-            "safe-buffer": "5.1.1"
+            "jwa": "^1.1.5",
+            "safe-buffer": "^5.0.1"
           }
         },
         "log-driver": {
@@ -132,8 +132,8 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "mime": {
@@ -151,26 +151,26 @@
           "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
           "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           }
         }
       }
@@ -193,10 +193,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "angular": {
@@ -234,7 +234,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "^4.14.0"
       }
     },
     "asynckit": {
@@ -257,8 +257,8 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
-        "follow-redirects": "1.5.0",
-        "is-buffer": "1.1.6"
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
       }
     },
     "balanced-match": {
@@ -277,7 +277,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "block-stream": {
@@ -285,7 +285,7 @@
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "boom": {
@@ -293,7 +293,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "brace-expansion": {
@@ -301,7 +301,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -330,9 +330,9 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
       "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
       "requires": {
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
       }
     },
     "co": {
@@ -350,7 +350,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -363,7 +363,7 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.14.tgz",
       "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
       "requires": {
-        "mime-db": "1.34.0"
+        "mime-db": ">= 1.34.0 < 2"
       },
       "dependencies": {
         "mime-db": {
@@ -383,9 +383,9 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "configstore": {
@@ -393,12 +393,12 @@
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.3.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "core-util-is": {
@@ -411,7 +411,7 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "cross-spawn": {
@@ -419,9 +419,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
@@ -429,7 +429,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -437,7 +437,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -499,11 +499,11 @@
       "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-1.0.4.tgz",
       "integrity": "sha1-AMLyOAGfJPbAoZSibUGhUw/+e8Q=",
       "requires": {
-        "d3-dispatch": "1.0.3",
-        "d3-drag": "1.2.1",
-        "d3-interpolate": "1.1.6",
-        "d3-selection": "1.3.0",
-        "d3-transition": "1.1.1"
+        "d3-dispatch": "1",
+        "d3-drag": "1",
+        "d3-interpolate": "1",
+        "d3-selection": "1",
+        "d3-transition": "1"
       }
     },
     "d3-chord": {
@@ -511,8 +511,8 @@
       "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-1.0.4.tgz",
       "integrity": "sha1-fexPC6iG9xP+ERxF92NBT290yiw=",
       "requires": {
-        "d3-array": "1.2.1",
-        "d3-path": "1.0.5"
+        "d3-array": "1",
+        "d3-path": "1"
       }
     },
     "d3-collection": {
@@ -535,8 +535,8 @@
       "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-1.2.1.tgz",
       "integrity": "sha512-Cg8/K2rTtzxzrb0fmnYOUeZHvwa4PHzwXOLZZPwtEs2SKLLKLXeYwZKBB+DlOxUvFmarOnmt//cU4+3US2lyyQ==",
       "requires": {
-        "d3-dispatch": "1.0.3",
-        "d3-selection": "1.3.0"
+        "d3-dispatch": "1",
+        "d3-selection": "1"
       }
     },
     "d3-dsv": {
@@ -544,9 +544,9 @@
       "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-1.0.8.tgz",
       "integrity": "sha512-IVCJpQ+YGe3qu6odkPQI0KPqfxkhbP/oM1XhhE/DFiYmcXKfCRub4KXyiuehV1d4drjWVXHUWx4gHqhdZb6n/A==",
       "requires": {
-        "commander": "2.15.1",
-        "iconv-lite": "0.4.23",
-        "rw": "1.3.3"
+        "commander": "2",
+        "iconv-lite": "0.4",
+        "rw": "1"
       }
     },
     "d3-ease": {
@@ -559,10 +559,10 @@
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.0.tgz",
       "integrity": "sha512-2HVQz3/VCQs0QeRNZTYb7GxoUCeb6bOzMp/cGcLa87awY9ZsPvXOGeZm0iaGBjXic6I1ysKwMn+g+5jSAdzwcg==",
       "requires": {
-        "d3-collection": "1.0.4",
-        "d3-dispatch": "1.0.3",
-        "d3-quadtree": "1.0.3",
-        "d3-timer": "1.0.7"
+        "d3-collection": "1",
+        "d3-dispatch": "1",
+        "d3-quadtree": "1",
+        "d3-timer": "1"
       }
     },
     "d3-format": {
@@ -575,7 +575,7 @@
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.9.1.tgz",
       "integrity": "sha512-l9wL/cEQkyZQYXw3xbmLsH3eQ5ij+icNfo4r0GrLa5rOCZR/e/3am45IQ0FvQ5uMsv+77zBRunLc9ufTWSQYFA==",
       "requires": {
-        "d3-array": "1.2.1"
+        "d3-array": "1"
       }
     },
     "d3-hierarchy": {
@@ -588,7 +588,7 @@
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.6.tgz",
       "integrity": "sha512-mOnv5a+pZzkNIHtw/V6I+w9Lqm9L5bG3OTXPM5A+QO0yyVMQ4W1uZhR+VOJmazaOZXri2ppbiZ5BUNWT0pFM9A==",
       "requires": {
-        "d3-color": "1.0.3"
+        "d3-color": "1"
       }
     },
     "d3-path": {
@@ -621,10 +621,10 @@
       "resolved": "https://registry.npmjs.org/d3-request/-/d3-request-1.0.6.tgz",
       "integrity": "sha512-FJj8ySY6GYuAJHZMaCQ83xEYE4KbkPkmxZ3Hu6zA1xxG2GD+z6P+Lyp+zjdsHf0xEbp2xcluDI50rCS855EQ6w==",
       "requires": {
-        "d3-collection": "1.0.4",
-        "d3-dispatch": "1.0.3",
-        "d3-dsv": "1.0.8",
-        "xmlhttprequest": "1.8.0"
+        "d3-collection": "1",
+        "d3-dispatch": "1",
+        "d3-dsv": "1",
+        "xmlhttprequest": "1"
       }
     },
     "d3-scale": {
@@ -632,13 +632,13 @@
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
       "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
       "requires": {
-        "d3-array": "1.2.1",
-        "d3-collection": "1.0.4",
-        "d3-color": "1.0.3",
-        "d3-format": "1.2.2",
-        "d3-interpolate": "1.1.6",
-        "d3-time": "1.0.8",
-        "d3-time-format": "2.1.1"
+        "d3-array": "^1.2.0",
+        "d3-collection": "1",
+        "d3-color": "1",
+        "d3-format": "1",
+        "d3-interpolate": "1",
+        "d3-time": "1",
+        "d3-time-format": "2"
       }
     },
     "d3-selection": {
@@ -651,7 +651,7 @@
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.2.0.tgz",
       "integrity": "sha1-RdAVOPBkuv0F6j1tLLdI/YxB93c=",
       "requires": {
-        "d3-path": "1.0.5"
+        "d3-path": "1"
       }
     },
     "d3-time": {
@@ -664,7 +664,7 @@
       "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
       "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
       "requires": {
-        "d3-time": "1.0.8"
+        "d3-time": "1"
       }
     },
     "d3-timer": {
@@ -677,12 +677,12 @@
       "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-1.1.1.tgz",
       "integrity": "sha512-xeg8oggyQ+y5eb4J13iDgKIjUcEfIOZs2BqV/eEmXm2twx80wTzJ4tB4vaZ5BKfz7XsI/DFmQL5me6O27/5ykQ==",
       "requires": {
-        "d3-color": "1.0.3",
-        "d3-dispatch": "1.0.3",
-        "d3-ease": "1.0.3",
-        "d3-interpolate": "1.1.6",
-        "d3-selection": "1.3.0",
-        "d3-timer": "1.0.7"
+        "d3-color": "1",
+        "d3-dispatch": "1",
+        "d3-ease": "1",
+        "d3-interpolate": "1",
+        "d3-selection": "^1.1.0",
+        "d3-timer": "1"
       }
     },
     "d3-voronoi": {
@@ -695,11 +695,11 @@
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-1.7.1.tgz",
       "integrity": "sha512-sZHQ55DGq5BZBFGnRshUT8tm2sfhPHFnOlmPbbwTkAoPeVdRTkB4Xsf9GCY0TSHrTD8PeJPZGmP/TpGicwJDJQ==",
       "requires": {
-        "d3-dispatch": "1.0.3",
-        "d3-drag": "1.2.1",
-        "d3-interpolate": "1.1.6",
-        "d3-selection": "1.3.0",
-        "d3-transition": "1.1.1"
+        "d3-dispatch": "1",
+        "d3-drag": "1",
+        "d3-interpolate": "1",
+        "d3-selection": "1",
+        "d3-transition": "1"
       }
     },
     "dashdash": {
@@ -707,7 +707,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "debug": {
@@ -733,7 +733,7 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "duplexify": {
@@ -741,10 +741,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
       "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -753,7 +753,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ecdsa-sig-formatter": {
@@ -761,8 +761,8 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
       "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
       "requires": {
-        "base64url": "2.0.0",
-        "safe-buffer": "5.1.1"
+        "base64url": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "end-of-stream": {
@@ -770,7 +770,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "ent": {
@@ -783,13 +783,13 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "extend": {
@@ -803,7 +803,8 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "facade-js": {
-      "version": "git://github.com/mdittmer/facade-js.git#bb5cc7b7c9b71ae2e7bc4e0a6a30c8d7a8b70b19"
+      "version": "git://github.com/mdittmer/facade-js.git#bb5cc7b7c9b71ae2e7bc4e0a6a30c8d7a8b70b19",
+      "from": "git://github.com/mdittmer/facade-js.git"
     },
     "fast-deep-equal": {
       "version": "1.0.0",
@@ -820,18 +821,19 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "foam2": {
-      "version": "git://github.com/foam-framework/foam2.git#f62d94d57a5d1cb4a77996da823ee5601ba1416c"
+      "version": "git://github.com/foam-framework/foam2.git#f62d94d57a5d1cb4a77996da823ee5601ba1416c",
+      "from": "git://github.com/foam-framework/foam2.git#mdn-confluence"
     },
     "follow-redirects": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
       "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
       "requires": {
-        "debug": "3.1.0"
+        "debug": "^3.1.0"
       }
     },
     "forever-agent": {
@@ -844,9 +846,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "fs.realpath": {
@@ -859,10 +861,10 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       }
     },
     "gcs-resumable-upload": {
@@ -870,11 +872,11 @@
       "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-0.10.2.tgz",
       "integrity": "sha1-fymz7iPc7EFwNnwHEUGCScZgVF8=",
       "requires": {
-        "configstore": "3.1.2",
-        "google-auto-auth": "0.10.1",
-        "pumpify": "1.5.1",
-        "request": "2.87.0",
-        "stream-events": "1.0.4"
+        "configstore": "^3.1.2",
+        "google-auto-auth": "^0.10.0",
+        "pumpify": "^1.4.0",
+        "request": "^2.85.0",
+        "stream-events": "^1.0.3"
       },
       "dependencies": {
         "gcp-metadata": {
@@ -882,8 +884,8 @@
           "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
           "integrity": "sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==",
           "requires": {
-            "axios": "0.18.0",
-            "extend": "3.0.1",
+            "axios": "^0.18.0",
+            "extend": "^3.0.1",
             "retry-axios": "0.3.2"
           }
         },
@@ -892,13 +894,13 @@
           "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.6.1.tgz",
           "integrity": "sha512-jYiWC8NA9n9OtQM7ANn0Tk464do9yhKEtaJ72pKcaBiEwn4LwcGYIYOfwtfsSm3aur/ed3tlSxbmg24IAT6gAg==",
           "requires": {
-            "axios": "0.18.0",
-            "gcp-metadata": "0.6.3",
-            "gtoken": "2.3.0",
-            "jws": "3.1.5",
-            "lodash.isstring": "4.0.1",
-            "lru-cache": "4.1.3",
-            "retry-axios": "0.3.2"
+            "axios": "^0.18.0",
+            "gcp-metadata": "^0.6.3",
+            "gtoken": "^2.3.0",
+            "jws": "^3.1.5",
+            "lodash.isstring": "^4.0.1",
+            "lru-cache": "^4.1.3",
+            "retry-axios": "^0.3.2"
           }
         },
         "google-auto-auth": {
@@ -906,10 +908,10 @@
           "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.10.1.tgz",
           "integrity": "sha512-iIqSbY7Ypd32mnHGbYctp80vZzXoDlvI9gEfvtl3kmyy5HzOcrZCIGCBdSlIzRsg7nHpQiHE3Zl6Ycur6TSodQ==",
           "requires": {
-            "async": "2.6.0",
-            "gcp-metadata": "0.6.3",
-            "google-auth-library": "1.6.1",
-            "request": "2.87.0"
+            "async": "^2.3.0",
+            "gcp-metadata": "^0.6.1",
+            "google-auth-library": "^1.3.1",
+            "request": "^2.79.0"
           }
         },
         "google-p12-pem": {
@@ -917,8 +919,8 @@
           "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.2.tgz",
           "integrity": "sha512-+EuKr4CLlGsnXx4XIJIVkcKYrsa2xkAmCvxRhX2HsazJzUBAJ35wARGeApHUn4nNfPD03Vl057FskNr20VaCyg==",
           "requires": {
-            "node-forge": "0.7.5",
-            "pify": "3.0.0"
+            "node-forge": "^0.7.4",
+            "pify": "^3.0.0"
           }
         },
         "gtoken": {
@@ -926,11 +928,11 @@
           "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
           "integrity": "sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==",
           "requires": {
-            "axios": "0.18.0",
-            "google-p12-pem": "1.0.2",
-            "jws": "3.1.5",
-            "mime": "2.3.1",
-            "pify": "3.0.0"
+            "axios": "^0.18.0",
+            "google-p12-pem": "^1.0.0",
+            "jws": "^3.1.4",
+            "mime": "^2.2.0",
+            "pify": "^3.0.0"
           }
         },
         "jws": {
@@ -938,8 +940,8 @@
           "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
           "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
           "requires": {
-            "jwa": "1.1.5",
-            "safe-buffer": "5.1.1"
+            "jwa": "^1.1.5",
+            "safe-buffer": "^5.0.1"
           }
         },
         "lru-cache": {
@@ -947,8 +949,8 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "mime": {
@@ -966,26 +968,26 @@
           "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
           "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           }
         },
         "stream-events": {
@@ -993,7 +995,7 @@
           "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.4.tgz",
           "integrity": "sha512-D243NJaYs/xBN2QnoiMDY7IesJFIK7gEhnvAYqJa5JvDdnh2dC4qDBwlCf0ohPpX2QRlA/4gnbnPd3rs3KxVcA==",
           "requires": {
-            "stubs": "3.0.0"
+            "stubs": "^3.0.0"
           }
         }
       }
@@ -1013,7 +1015,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -1021,12 +1023,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -1049,8 +1051,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "hash-stream-validation": {
@@ -1058,7 +1060,7 @@
       "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.1.tgz",
       "integrity": "sha1-7Mm5l7IYvluzEphii7gHhptz3NE=",
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.0"
       }
     },
     "hawk": {
@@ -1066,10 +1068,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "hoek": {
@@ -1082,9 +1084,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -1092,11 +1094,12 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "id-js": {
-      "version": "git://github.com/mdittmer/id-js.git#04a7713aa6d3b85b5d82b57401e6d527068da687"
+      "version": "git://github.com/mdittmer/id-js.git#04a7713aa6d3b85b5d82b57401e6d527068da687",
+      "from": "git://github.com/mdittmer/id-js.git"
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -1108,8 +1111,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1198,7 +1201,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -1230,7 +1233,7 @@
         "base64url": "2.0.0",
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.9",
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "lcid": {
@@ -1238,7 +1241,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "locate-path": {
@@ -1246,8 +1249,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -1265,8 +1268,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "make-dir": {
@@ -1274,7 +1277,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "requires": {
-        "pify": "3.0.0"
+        "pify": "^3.0.0"
       }
     },
     "materialize-css": {
@@ -1282,9 +1285,9 @@
       "resolved": "https://registry.npmjs.org/materialize-css/-/materialize-css-0.98.2.tgz",
       "integrity": "sha1-+eQjn9J+KpF6DeN5101Qji2S7I4=",
       "requires": {
-        "hammerjs": "2.0.8",
-        "jquery": "2.2.4",
-        "node-archiver": "0.3.0"
+        "hammerjs": "^2.0.4",
+        "jquery": "^2.1.4",
+        "node-archiver": "^0.3.0"
       },
       "dependencies": {
         "jquery": {
@@ -1299,7 +1302,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "methmeth": {
@@ -1317,7 +1320,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.30.0"
       }
     },
     "mimic-fn": {
@@ -1330,7 +1333,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1361,8 +1364,8 @@
       "resolved": "https://registry.npmjs.org/node-archiver/-/node-archiver-0.3.0.tgz",
       "integrity": "sha1-ufGv5QBtC98pJgGBgzoHCXi8aUc=",
       "requires": {
-        "fstream": "1.0.11",
-        "tar": "2.2.1"
+        "fstream": "^1.0.10",
+        "tar": "^2.2.1"
       }
     },
     "npm-run-path": {
@@ -1370,7 +1373,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "number-is-nan": {
@@ -1385,6 +1388,7 @@
     },
     "object-graph-js": {
       "version": "git://github.com/mdittmer/object-graph-js.git#5280aec138c911659c188975cb31cfa0113a2beb",
+      "from": "git://github.com/mdittmer/object-graph-js.git",
       "requires": {
         "facade-js": "git://github.com/mdittmer/facade-js.git#bb5cc7b7c9b71ae2e7bc4e0a6a30c8d7a8b70b19",
         "id-js": "git://github.com/mdittmer/id-js.git#04a7713aa6d3b85b5d82b57401e6d527068da687",
@@ -1396,7 +1400,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "os-locale": {
@@ -1404,9 +1408,9 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "p-finally": {
@@ -1419,7 +1423,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -1427,7 +1431,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "1.2.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-try": {
@@ -1475,8 +1479,8 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -1484,9 +1488,9 @@
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "requires": {
-        "duplexify": "3.6.0",
-        "inherits": "2.0.3",
-        "pump": "2.0.1"
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       },
       "dependencies": {
         "duplexify": {
@@ -1494,10 +1498,10 @@
           "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
           "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
           "requires": {
-            "end-of-stream": "1.4.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.4",
-            "stream-shift": "1.0.0"
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
           }
         }
       }
@@ -1517,13 +1521,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
       "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "request": {
@@ -1531,28 +1535,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "require-directory": {
@@ -1575,8 +1579,8 @@
       "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-3.3.1.tgz",
       "integrity": "sha512-PjAmtWIxjNj4Co/6FRtBl8afRP3CxrrIAnUzb1dzydfROd+6xt7xAebFeskgQgkfFf8NmzrXIoaB3HxmswXyxw==",
       "requires": {
-        "request": "2.83.0",
-        "through2": "2.0.3"
+        "request": "^2.81.0",
+        "through2": "^2.0.0"
       }
     },
     "rimraf": {
@@ -1584,7 +1588,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "rw": {
@@ -1612,7 +1616,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -1635,7 +1639,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "split-array-stream": {
@@ -1643,8 +1647,8 @@
       "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-1.0.3.tgz",
       "integrity": "sha1-0rdajl4Ngk1S/eyLgiWDncLjXfo=",
       "requires": {
-        "async": "2.6.0",
-        "is-stream-ended": "0.1.3"
+        "async": "^2.4.0",
+        "is-stream-ended": "^0.1.0"
       }
     },
     "sshpk": {
@@ -1652,14 +1656,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stream-events": {
@@ -1667,7 +1671,7 @@
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.2.tgz",
       "integrity": "sha1-q/OfZsCJCk63lbyNXoWbJhW1kLI=",
       "requires": {
-        "stubs": "3.0.0"
+        "stubs": "^3.0.0"
       }
     },
     "stream-shift": {
@@ -1685,8 +1689,8 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "string_decoder": {
@@ -1694,7 +1698,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -1707,7 +1711,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
-        "ansi-regex": "3.0.0"
+        "ansi-regex": "^3.0.0"
       }
     },
     "strip-eof": {
@@ -1725,9 +1729,9 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "through2": {
@@ -1735,8 +1739,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.4",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "tough-cookie": {
@@ -1744,7 +1748,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "tunnel-agent": {
@@ -1752,7 +1756,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -1771,7 +1775,7 @@
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
-        "crypto-random-string": "1.0.0"
+        "crypto-random-string": "^1.0.0"
       }
     },
     "util-deprecate": {
@@ -1789,25 +1793,27 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "web-api-confluence-dashboard": {
       "version": "git://github.com/mdittmer/confluence.git#53d37216539948b094063d0f94bf7c986e6fb875",
+      "from": "git://github.com/mdittmer/confluence.git#mdn",
       "requires": {
-        "@uirouter/angularjs": "1.0.18",
-        "angular": "1.7.2",
-        "d3": "4.13.0",
+        "@uirouter/angularjs": "^1.0.0",
+        "angular": "^1.6.3",
+        "d3": "^4.7.4",
         "foam2": "git://github.com/foam-framework/foam2.git#c2a437ec6c299a2b6f3b78981035f133f5f5f77b",
-        "jquery": "3.3.1",
-        "materialize-css": "0.98.2",
+        "jquery": "^3.2.1",
+        "materialize-css": "^0.98.1",
         "object-graph-js": "git://github.com/mdittmer/object-graph-js.git#5280aec138c911659c188975cb31cfa0113a2beb"
       },
       "dependencies": {
         "foam2": {
-          "version": "git://github.com/foam-framework/foam2.git#c2a437ec6c299a2b6f3b78981035f133f5f5f77b"
+          "version": "git://github.com/foam-framework/foam2.git#c2a437ec6c299a2b6f3b78981035f133f5f5f77b",
+          "from": "foam2@git://github.com/foam-framework/foam2.git#c2a437ec6c299a2b6f3b78981035f133f5f5f77b"
         }
       }
     },
@@ -1816,7 +1822,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -1829,8 +1835,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1843,7 +1849,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "string-width": {
@@ -1851,9 +1857,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "strip-ansi": {
@@ -1861,7 +1867,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         }
       }
@@ -1876,9 +1882,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "xdg-basedir": {
@@ -1903,8 +1909,9 @@
     },
     "ya-stdlib-js": {
       "version": "git://github.com/mdittmer/ya-stdlib-js.git#7ddbb708e9d8db8095462709c3721f330fe13cce",
+      "from": "git://github.com/mdittmer/ya-stdlib-js.git",
       "requires": {
-        "json-stable-stringify": "1.0.1"
+        "json-stable-stringify": "^1.0.1"
       }
     },
     "yallist": {
@@ -1917,18 +1924,18 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
       "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "requires": {
-        "cliui": "4.0.0",
-        "decamelize": "1.2.0",
-        "find-up": "2.1.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "9.0.2"
+        "cliui": "^4.0.0",
+        "decamelize": "^1.1.1",
+        "find-up": "^2.1.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^9.0.2"
       }
     },
     "yargs-parser": {
@@ -1936,7 +1943,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
       "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "mdn-confluence",
   "version": "0.0.7",
-  "description": "User support tool for maintaining MDN compatability data using Web API Confluence data.",
+  "description": "User support tool for maintaining MDN compatibility data using Web API Confluence data.",
   "scripts": {
     "build": "node ./scripts/build.js",
     "confluence": "node ./main/confluence.es6.js",
     "generate": "node ./main/generate.es6.js",
     "import": "node ./main/import.es6.js",
-    "postinstall": "mkdir -p data/browser-compat-data && npm run build",
+    "postinstall": "node ./scripts/post_install.js && npm run build",
     "uiBuild": "./scripts/install_firebase.sh && npm run build",
     "uiStart": "npm run build && firebase serve"
   },

--- a/scripts/post_install.js
+++ b/scripts/post_install.js
@@ -1,0 +1,67 @@
+// Copyright 2018. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+'use strict';
+
+const path = require('path');
+const process = require('process');
+const { spawn } = require('child_process');
+
+const scriptDir = __dirname;
+const sourceRoot = path.join(scriptDir, '..');
+
+const isWinPlatform = (process.platform === "win32");
+
+function runCommand(cmd, ...args) {
+
+  try {
+
+    let spawnedChild;
+    const cmdWithArgs = cmd + ' ' + args.join(' ');
+    console.log('Executing command:', cmdWithArgs);
+
+    if (isWinPlatform) {
+
+      spawnedChild = spawn('cmd.exe', ['/c', cmdWithArgs]);
+
+    } else {
+
+      spawnedChild = spawn(cmdWithArgs, { shell: true });
+
+    }
+
+    if (spawnedChild) {
+
+      spawnedChild.stdout.on('data', (data) => {
+        console.log(data.toString());
+      });
+
+      spawnedChild.stderr.on('data', (data) => {
+        console.error(data.toString());
+      });
+
+      spawnedChild.on('exit', (code) => {
+        console.log(`Child exited with code ${code}`);
+      });
+
+    }
+
+  } catch (err) {
+
+    console.error(err);
+
+  }
+
+}
+
+// Run the commands.
+if (isWinPlatform) {
+
+  runCommand('mkdir', path.join('data', 'browser-compat-data'));
+
+} else {
+
+  runCommand('mkdir', '-p', path.join('data', 'browser-compat-data'));
+
+}

--- a/scripts/post_install.js
+++ b/scripts/post_install.js
@@ -8,60 +8,90 @@ const path = require('path');
 const process = require('process');
 const { spawn } = require('child_process');
 
-const scriptDir = __dirname;
-const sourceRoot = path.join(scriptDir, '..');
+//
+// Path constants.
+//
 
-const isWinPlatform = (process.platform === "win32");
+const SCRIPT_DIR = __dirname;
+const SOURCE_ROOT = path.join(SCRIPT_DIR, '..');
 
+//
+// Platform vars.
+//
+
+const isWinPlatform = ('win32' === process.platform);
+
+/**
+ * Executes any arbitrary shell commands.
+ * 
+ * @param {string} cmd The command to execute. 
+ * @param {...string} arg Optional arguments for the provided command. 
+ */
 function runCommand(cmd, ...args) {
 
   try {
 
     let spawnedChild;
     const cmdWithArgs = cmd + ' ' + args.join(' ');
+
     console.log('Executing command:', cmdWithArgs);
 
+    // Execute the provided command in a win32 env.
     if (isWinPlatform) {
 
+      // Spawn a child.
       spawnedChild = spawn('cmd.exe', ['/c', cmdWithArgs]);
 
-    } else {
+    } else {  // Execute the provided command in a env. other than win32.
 
+      // Spawn a child.
       spawnedChild = spawn(cmdWithArgs, { shell: true });
 
     }
 
     if (spawnedChild) {
 
+      // Log the stdin stream.
       spawnedChild.stdout.on('data', (data) => {
+
         console.log(data.toString());
+
       });
 
+      // Log the stderr stream.
       spawnedChild.stderr.on('data', (data) => {
+
         console.error(data.toString());
+
       });
 
+      // Log the exit status.
       spawnedChild.on('exit', (code) => {
+
         console.log(`Child exited with code ${code}`);
+
       });
 
     }
 
   } catch (err) {
 
+    // log the error.
     console.error(err);
 
   }
 
 }
 
-// Run the commands.
+// Create the 'data/browser-compat-data' dir.
 if (isWinPlatform) {
 
+  // win32.
   runCommand('mkdir', path.join('data', 'browser-compat-data'));
 
 } else {
 
+  // darwin or linux.
   runCommand('mkdir', '-p', path.join('data', 'browser-compat-data'));
 
 }


### PR DESCRIPTION
The postscript fails on win32 machine. And as [browser-compat-data](https://github.com/mdn/browser-compat-data) is dependent on this package the ```npm install``` fails for it too. This pull request aims to fix only postinstall script so that ```npm install``` can be fixed for win32 environment.

This is my first pull request, so please help me out in fixing anything that is not correct.