### PR TITLE
Bump the package version to 0.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdn-confluence",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "User support tool for maintaining MDN compatibility data using Web API Confluence data.",
   "scripts": {
     "build": "node ./scripts/build.js",


### PR DESCRIPTION
This is to make it immediately clear it no longer matches the version in
https://www.npmjs.com/package/mdn-confluence, which won't be updated.