### PR TITLE
Update the BCD peer dependency to avoid warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "yargs": "^11.1.0"
   },
   "peerDependencies": {
-    "mdn-browser-compat-data": "^0.0.32"
+    "mdn-browser-compat-data": "^0.0.66"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "yargs": "^11.1.0"
   },
   "peerDependencies": {
-    "mdn-browser-compat-data": "git://github.com/mdn/browser-compat-data.git"
+    "mdn-browser-compat-data": "^0.0.32"
   }
 }


### PR DESCRIPTION
With the dependency as it was, `npm install` in BCD resulted in this
warning:
> mdn-confluence@0.0.7 requires a peer of mdn-browser-compat-data@git://github.com/mdn/browser-compat-data.git but none is installed. You must install peer dependencies yourself.

Instead depend on 0.0.32, the first release after https://github.com/mdn/browser-compat-data/pull/1723.