### PR TITLE
Remove the BCD peer dependency to avoid warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,5 @@
     "foam2": "git://github.com/foam-framework/foam2.git#mdn-confluence",
     "web-api-confluence-dashboard": "git://github.com/mdittmer/confluence.git#mdn",
     "yargs": "^11.1.0"
-  },
-  "peerDependencies": {
-    "mdn-browser-compat-data": "git://github.com/mdn/browser-compat-data.git"
   }
 }


### PR DESCRIPTION
With the dependency as it was, `npm install` in BCD resulted in this
warning:
> mdn-confluence@0.0.7 requires a peer of mdn-browser-compat-data@git://github.com/mdn/browser-compat-data.git but none is installed. You must install peer dependencies yourself.

https://github.com/mdittmer/mdn-confluence/pull/34 was one attempt to
resolve this that didn't work, because the two modules don't have a peer
relationship, the dependency is rather a plain one.

mdn-confluence should be used from the latest BCD since otherwise
conflicts are likely, and package-lock.json in BCD will record the exact
commit for reproducability.