### PR TITLE
Depend on the same branch of foam2 as confluence does

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@google-cloud/storage": "^1.7.0",
     "compare-versions": "^3.4.0",
-    "foam2": "git://github.com/foam-framework/foam2.git#mdn-confluence",
+    "foam2": "git://github.com/foam-framework/foam2.git#confluence",
     "web-api-confluence-dashboard": "git://github.com/mdittmer/confluence.git#mdn",
     "yargs": "^11.1.0"
   }


### PR DESCRIPTION
https://github.com/mdittmer/confluence/blob/53d37216539948b094063d0f94bf7c986e6fb875/package.json#L34

The confluence branch is ahead of the mdn-confluence branch:
https://github.com/foam-framework/foam2/compare/mdn-confluence...confluence

There many commits and changes, but most are from master.

Note that this still doesn't avoid two copies of foam2:
https://github.com/mdittmer/mdn-confluence/issues/38