### PR TITLE
Switch the confluence dependency to GoogleChromeLabs/confluence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,17 +114,17 @@
       "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg=="
     },
     "@uirouter/angularjs": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/@uirouter/angularjs/-/angularjs-1.0.18.tgz",
-      "integrity": "sha512-tswhwMMBDnbGOZnnCVpnA0pbd7dXkBck1HO0WY7fw8GO3dKbWAAc/rL0479dLypR89UDDGym5leTvZCLW4cJnA==",
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@uirouter/angularjs/-/angularjs-1.0.22.tgz",
+      "integrity": "sha512-d0SvdbXAav+Z6gCJd7gmn2eXEUtO3RvYcSLwtPaE8+7QiWHpSKNfGdD4D3noXhO2yUTz/AwaxsiRFMCwgVI0UQ==",
       "requires": {
-        "@uirouter/core": "5.0.19"
+        "@uirouter/core": "5.0.23"
       }
     },
     "@uirouter/core": {
-      "version": "5.0.19",
-      "resolved": "https://registry.npmjs.org/@uirouter/core/-/core-5.0.19.tgz",
-      "integrity": "sha512-wow+CKRThUAQkiTLNQCBsKQIU3NbH8GGH/w/TrcjKdvkZQA2jQB9QSqmmZxj7XNoZXY7QVcSSc4DWmxuSeAWmQ=="
+      "version": "5.0.23",
+      "resolved": "https://registry.npmjs.org/@uirouter/core/-/core-5.0.23.tgz",
+      "integrity": "sha512-rwFOH++z/KY8y+h0IOpQ5uC8Nim6E0EBCQrIjhVCr+XKYXgpK+VdtuOLFdogvbJ3AAi5Z7ei00qdEr7Did5CAg=="
     },
     "abort-controller": {
       "version": "2.0.2",
@@ -154,9 +154,9 @@
       }
     },
     "angular": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/angular/-/angular-1.7.2.tgz",
-      "integrity": "sha512-JcKKJbBdybUsmQ6x1M3xWyTYQ/ioVKJhSByEAjqrhmlOfvMFdhfMqAx5KIo8rLGk4DFolYPcCSgssjgTVjCtRQ=="
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.7.7.tgz",
+      "integrity": "sha512-MH3JEGd8y/EkNCKJ8EV6Ch0j9X0rZTta/QVIDpBWaIdfh85/e5KO8+ZKgvWIb02MQuiS20pDFmMFlv4ZaLcLWg=="
     },
     "ansi-regex": {
       "version": "3.0.0",
@@ -288,9 +288,9 @@
       }
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
     },
     "compare-versions": {
       "version": "3.4.0",
@@ -738,6 +738,10 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "facade-js": {
+      "version": "git://github.com/mdittmer/facade-js.git#bb5cc7b7c9b71ae2e7bc4e0a6a30c8d7a8b70b19",
+      "from": "git://github.com/mdittmer/facade-js.git"
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -847,9 +851,9 @@
       }
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -974,12 +978,16 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "id-js": {
+      "version": "git://github.com/mdittmer/id-js.git#04a7713aa6d3b85b5d82b57401e6d527068da687",
+      "from": "git://github.com/mdittmer/id-js.git"
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -1078,10 +1086,23 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -1270,6 +1291,15 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
+    "object-graph-js": {
+      "version": "git://github.com/mdittmer/object-graph-js.git#71a9f1eef3cece1b31fb25e90d874653d2826207",
+      "from": "git://github.com/mdittmer/object-graph-js.git",
+      "requires": {
+        "facade-js": "git://github.com/mdittmer/facade-js.git#bb5cc7b7c9b71ae2e7bc4e0a6a30c8d7a8b70b19",
+        "id-js": "git://github.com/mdittmer/id-js.git#04a7713aa6d3b85b5d82b57401e6d527068da687",
+        "ya-stdlib-js": "git://github.com/mdittmer/ya-stdlib-js.git#7ddbb708e9d8db8095462709c3721f330fe13cce"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1454,11 +1484,11 @@
       }
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
       }
     },
     "rw": {
@@ -1681,24 +1711,21 @@
       }
     },
     "web-api-confluence-dashboard": {
-      "version": "git://github.com/mdittmer/confluence.git#53d37216539948b094063d0f94bf7c986e6fb875",
-      "from": "git://github.com/mdittmer/confluence.git#mdn",
+      "version": "git://github.com/GoogleChromeLabs/confluence.git#53d37216539948b094063d0f94bf7c986e6fb875",
+      "from": "git://github.com/GoogleChromeLabs/confluence.git#mdn-confluence",
       "requires": {
         "@uirouter/angularjs": "^1.0.0",
         "angular": "^1.6.3",
         "d3": "^4.7.4",
-        "foam2": "git://github.com/foam-framework/foam2.git#c2a437ec6c299a2b6f3b78981035f133f5f5f77b",
+        "foam2": "git://github.com/foam-framework/foam2.git#4e494ae93cbd329b6b49b191c6e1c937b8945bde",
         "jquery": "^3.2.1",
-        "materialize-css": "^0.98.1"
+        "materialize-css": "^0.98.1",
+        "object-graph-js": "git://github.com/mdittmer/object-graph-js.git#71a9f1eef3cece1b31fb25e90d874653d2826207"
       },
       "dependencies": {
         "foam2": {
-          "version": "git://github.com/foam-framework/foam2.git#c2a437ec6c299a2b6f3b78981035f133f5f5f77b",
-          "from": "foam2@git://github.com/foam-framework/foam2.git#c2a437ec6c299a2b6f3b78981035f133f5f5f77b"
-        },
-        "object-graph-js": {
-          "version": "git://github.com/mdittmer/object-graph-js.git#71a9f1eef3cece1b31fb25e90d874653d2826207",
-          "from": "git://github.com/mdittmer/object-graph-js.git#71a9f1eef3cece1b31fb25e90d874653d2826207"
+          "version": "git://github.com/foam-framework/foam2.git#4e494ae93cbd329b6b49b191c6e1c937b8945bde",
+          "from": "git://github.com/foam-framework/foam2.git#confluence"
         }
       }
     },
@@ -1791,6 +1818,13 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "ya-stdlib-js": {
+      "version": "git://github.com/mdittmer/ya-stdlib-js.git#7ddbb708e9d8db8095462709c3721f330fe13cce",
+      "from": "git://github.com/mdittmer/ya-stdlib-js.git",
+      "requires": {
+        "json-stable-stringify": "^1.0.1"
+      }
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@google-cloud/storage": "^2.0.0",
     "compare-versions": "^3.4.0",
     "foam2": "git://github.com/foam-framework/foam2.git#mdn-confluence",
-    "web-api-confluence-dashboard": "git://github.com/mdittmer/confluence.git#mdn",
+    "web-api-confluence-dashboard": "git://github.com/GoogleChromeLabs/confluence.git#mdn-confluence",
     "yargs": "^11.1.0"
   }
 }


### PR DESCRIPTION
The mdn-confluence branch in this repo points to the same commit
(53d37216539948b094063d0f94bf7c986e6fb875) as mdn in the old.

The change of branch name is for consistency with foam2, and because the
mdn branch is used in https://github.com/GoogleChromeLabs/confluence/pull/344.

This will allow further changes on that branch.