### PR TITLE
Revamp the core approach to converting Confluence to BCD

### DIFF
--- a/main/generate.es6.js
+++ b/main/generate.es6.js
@@ -80,19 +80,16 @@ mdn.InfraServerContextProvider.create({
 }).install();
 
 (async function() {
-  const confluenceSink =
-        await mdn.ConfluenceImporter.create({
-          releaseJsonUrl: argv.confluenceReleaseUrl,
-          gridRowsJsonUrl: argv.confluenceDataUrl,
-        }).importClassAndData();
-
-  const confluenceDAO = foam.dao.MDAO.create({of: confluenceSink.of});
-  await Promise.all(confluenceSink.array.map(item => confluenceDAO.put(item)));
   await mdn.CompatConfluenceJsonGenerator.create({
+    confluenceReleaseUrl: argv.confluenceReleaseUrl,
+    confluenceDataUrl: argv.confluenceDataUrl,
     fillOnly: argv.fillOnly,
     remove: argv.remove,
     outputDir: argv.outputDir,
     interfaces: argv.interfaces,
     browsers: argv.browsers,
-  }).generateJson(confluenceDAO);
-})();
+  }).generateJson();
+})().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@google-cloud/storage": "^2.0.0",
     "compare-versions": "^3.4.0",
     "foam2": "git://github.com/foam-framework/foam2.git#mdn-confluence",
+    "node-fetch": "^2.3.0",
     "web-api-confluence-dashboard": "git://github.com/GoogleChromeLabs/confluence.git#mdn-confluence-2",
     "yargs": "^11.1.0"
   }

--- a/public/lib/org/mozilla/mdn/CompatJsonAdapter.es6.js
+++ b/public/lib/org/mozilla/mdn/CompatJsonAdapter.es6.js
@@ -75,7 +75,13 @@ foam.CLASS({
           }
         } else if (value && support[browser].version_removed) {
           // This is the case of an API being added, removed, and then added
-          // again. TODO: handle it.
+          // again. Put the information in `maintainer_notes` for now.
+          if (!support[browser].maintainer_notes) {
+            support[browser].maintainer_notes = [];
+          }
+          support[browser].maintainer_notes.push(`Removed in ${support[browser].version_removed}`);
+          support[browser].maintainer_notes.push(`Added in ${version}`);
+          delete support[browser].version_removed;
         }
       }
 


### PR DESCRIPTION
There were a number of issues here:
 - Releases from different OSes were mixed and could lead to very
   strange suggested edits, especially for Safari.
 - The version numbers suggested didn't always exist in BCD,
   sometimes because they weren't correctly trimmed.
 - Patches which had both `version_added` and `version_removed`
   could be partially applied, which was the default because
   `version_removed` was only added with --remove.
 - Safari for iOS versions were incorrect per BCD guidelines.

This was addressed by:
 - Only using one browser+OS combination for each BCD browser.
 - Getting the version number from BCD by matching components.
 - `patchPredicte` considers the whole patch, not its parts.

Also, confluenceRowToCompatJsonFragment was reduced to a single scan
through the row, which necessitated changing how the `support` object
is updated. Important changes:
 - Existing data is not used, that's left to `patchPredicate`.
 - `version_added` is never set to true, but uses ≤ if necessary.
 - Rows where support is true for every release of a browser are
   no longer skipped. (Was in the `p => !!p.f(row)` filter.)

The many repeated calls to `getMdnBrowserRelease` could be hoisted out
to be less wasteful, but speed is not of the essence here.

Drive-by: replace use of foam.String.isInstance